### PR TITLE
Fix: コメント投稿からユーザー詳細へのリンクをuuidからuserUuidに変更 #57

### DIFF
--- a/src/components/pages/comment/PostCommentItem.tsx
+++ b/src/components/pages/comment/PostCommentItem.tsx
@@ -94,10 +94,10 @@ const PostCommentItem = ({ postComment, query, handleGetComments, replies }: Pos
             <Paper css={paperStyle}>
               <Grid container wrap="nowrap" spacing={2}>
                 <Grid item>
-                  <Avatar src={postComment.attributes.userImage?.url} css={avatar} component={Link} to={`/user/${postComment?.attributes.uuid}`} />
+                  <Avatar src={postComment.attributes.userImage?.url} css={avatar} component={Link} to={`/user/${postComment?.attributes.userUuid}`} />
                 </Grid>
                 <Grid container justifyContent="left" item xs zeroMinWidth>
-                  <Typography variant="body2" component={Link} to={`/user/${postComment?.attributes.uuid}`} css={userLink}>
+                  <Typography variant="body2" component={Link} to={`/user/${postComment?.attributes.userUuid}`} css={userLink}>
                     {postComment.attributes.userName}
                   </Typography>
                   <Typography variant="body2" css={timeStyle}>

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -101,7 +101,7 @@ export interface MatchPostUpdate {
 export interface MatchPostComment {
   attributes: {
     id: string;
-    uuid: string;
+    userUuid: string;
     content: string;
     rootId: string;
     userId: string;


### PR DESCRIPTION
## 概要

Closes #57 